### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mac-fdisk (0.1-19) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Sat, 15 Sep 2018 11:05:08 +0100
+
 mac-fdisk (0.1-18) unstable; urgency=medium
 
   * New maintainer:

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Build-Depends: debhelper
 Maintainer: John Paul Adrian Glaubitz <glaubitz@physik.fu-berlin.de>
 Standards-Version: 3.5.8.0
-Vcs-Git: git://github.com/glaubitz/mac-fdisk-debian.git
+Vcs-Git: https://github.com/glaubitz/mac-fdisk-debian.git
 Vcs-Browser: https://github.com/glaubitz/mac-fdisk-debian
 
 Package: mac-fdisk


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
